### PR TITLE
認可処理の実装

### DIFF
--- a/src/main/java/oit/is/nine/minus/security/Sample3AuthConfiguration.java
+++ b/src/main/java/oit/is/nine/minus/security/Sample3AuthConfiguration.java
@@ -29,7 +29,7 @@ public class Sample3AuthConfiguration {
             .logoutUrl("/logout")
             .logoutSuccessUrl("/"))
         .authorizeHttpRequests(authz -> authz
-            .requestMatchers(AntPathRequestMatcher.antMatcher("/**")).authenticated()
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/sample3/**")).authenticated()
             .requestMatchers(AntPathRequestMatcher.antMatcher("/**")).permitAll()); // それ以外は全員アクセス可能
     return http.build();
   }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,1 +1,13 @@
-hoge
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>SpringBoot Samples</title>
+</head>
+
+<body>
+  <a href="/sample3/step1">sample3-1へのGETをリクエスト(認証付き)</a>
+</body>
+
+</html>


### PR DESCRIPTION
以下の3つの認可に伴う処理をSample3AuthConfiguration.javaに実装すること
SpringSecurityのフォームを利用する
/sample3 で始まるURLへのアクセス時にのみ認証を必要とする (例：http://localhost:8080/sample3/hoge)
ログアウト時にはトップページ (http://localhost:8080/)に戻る